### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ end
 
 tokens(:ID, *keywords.values)
 
-rule(:ID, /\w[\w\d]*/) do |lexer, token|
+rule(:ID, /[_[:alpha:]][_[:alnum:]]*/) do |lexer, token|
   token.name = lexer.class.keywords.fetch(token.value.to_sym, :ID)
   token
 end
@@ -213,7 +213,7 @@ end
 By default token value is the text that was matched by the rule. However, the token value can be changed to any object. For example, when processing identifiers you may wish to return both identifier name and actual value.
 
 ```ruby
-rule(:ID, /\w[\w\d]*/) do |lexer, token|
+rule(:ID, /[_[:alpha:]][_[:alnum:]]*/) do |lexer, token|
   token.value = [token.value, lexer.class.keywords[token.value]]
   token
 end

--- a/README.md
+++ b/README.md
@@ -245,10 +245,10 @@ Calling the `advance_line` method the `current_line` is updated for the underlyi
 
 ### 1.8 Ignored characters
 
-For any character that should be completely ignored in the input stream use the `ignore` rule. Usually this is used to skip over whitespace and other non-essential characters. For example:
+For any character that should be completely ignored in the input stream use the `ignore` method. Usually this is used to skip over whitespace and other non-essential characters. For example:
 
 ```ruby
-ignore = " \t" # => Ignore whitespace and tabs
+ignore " \t" # => Ignore whitespace and tabs
 ```
 
 You could create a rule to achieve similar behaviour, however you are encourage to use this method as it has increased performance over the rule regular expression matching.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ class MyLexer < Lex::Lexer
   rule(:DIVIDE, /\//)
   rule(:LPAREN, /\(/)
   rule(:RPAREN, /\)/)
-  rule(:ID,     /\A[_\$a-zA-Z][_\$0-9a-zA-Z]*/)
+  rule(:ID,     /[_\$a-zA-Z][_\$0-9a-zA-Z]*/)
 
   # A regular expression rules with actions
   rule(:NUMBER, /[0-9]+/) do |lexer, token|

--- a/lib/lex/lexer.rb
+++ b/lib/lex/lexer.rb
@@ -26,11 +26,8 @@ module Lex
                    :state_lexemes
 
     def initialize(options = {}, &block)
-      @current_line     = 1
-      @current_pos      = 1 # Position in input
-      @char_pos_in_line = 0
-      @current_state    = :initial
-      @state_stack      = []
+      rewind
+
       @logger           = Lex::Logger.new
       @linter           = Lex::Linter.new
       @debug            = options[:debug]
@@ -196,9 +193,11 @@ module Lex
     # Reset the internal state of the lexer
     # @api public
     def rewind
-      @line = 1
-      @column = 1
-      @stack = []
+      @current_line     = 1
+      @current_pos      = 1 # Position in input
+      @char_pos_in_line = 0
+      @current_state    = :initial
+      @state_stack      = []
     end
 
     private

--- a/lib/lex/lexer.rb
+++ b/lib/lex/lexer.rb
@@ -96,11 +96,12 @@ module Lex
         end
 
         if longest_token
+          longest_token_value_length = longest_token.value.length
           if longest_token.action
             new_token = longest_token.action.call(self, longest_token)
             # No value returned from action move to the next token
             if new_token.nil? || !new_token.is_a?(Token)
-              chars_to_skip = longest_token.value.to_s.length
+              chars_to_skip = longest_token_value_length
               scanner.pos += chars_to_skip
               unless longest_token.name == :newline
                 @char_pos_in_line += chars_to_skip
@@ -108,7 +109,7 @@ module Lex
               next
             end
           end
-          move_by = longest_token.value.to_s.length
+          move_by = longest_token_value_length
           start_char_pos_in_token = @char_pos_in_line + current_char.size
           longest_token.update_line(current_line, start_char_pos_in_token)
           advance_column(move_by)

--- a/spec/unit/keyword_spec.rb
+++ b/spec/unit/keyword_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Lex::Lexer, 'keywords' do
 
       tokens(:IDENTIFIER, *keywords.values)
 
-      rule(:IDENTIFIER, /\w[\w\d]*/) do |lexer, token|
+      rule(:IDENTIFIER, /[_[:alpha:]][_[:alnum:]]*/) do |lexer, token|
         token.name = lexer.class.keywords.fetch(token.value.to_sym, :IDENTIFIER)
         token
       end

--- a/spec/unit/lex_spec.rb
+++ b/spec/unit/lex_spec.rb
@@ -5,10 +5,6 @@ require 'spec_helper'
 RSpec.describe Lex::Lexer, 'lex' do
 
   it "tokenizes simple input" do
-    code = unindent(<<-EOS)
-      x = 5 + 44 * (s - t)
-    EOS
-
     stub_const('MyLexer', Class.new(Lex::Lexer) do
       tokens(
         :NUMBER,
@@ -42,7 +38,11 @@ RSpec.describe Lex::Lexer, 'lex' do
 
       ignore " \t"
     end)
+
     my_lexer = MyLexer.new
+    code = unindent(<<-EOS)
+      x = 5 + 44 * (s - t)
+    EOS
     expect(my_lexer.lex(code).map(&:to_ary)).to eq([
       [:IDENTIFIER, 'x', 1, 1],
       [:EQUALS, '=', 1, 3],
@@ -55,6 +55,25 @@ RSpec.describe Lex::Lexer, 'lex' do
       [:MINUS, '-', 1, 17],
       [:IDENTIFIER, 't', 1, 19],
       [:RPAREN, ')', 1, 20]
+    ])
+
+    # Test that lexer is correctly parsing if created token value isn't equal to original text
+    my_lexer = MyLexer.new
+    code_with_prefix = unindent(<<-EOS)
+      x = 05 + 0044 * (s - t)
+    EOS
+    expect(my_lexer.lex(code_with_prefix).map(&:to_ary)).to eq([
+      [:IDENTIFIER, 'x', 1, 1],
+      [:EQUALS, '=', 1, 3],
+      [:NUMBER, 5, 1, 5],
+      [:PLUS, '+', 1, 8],
+      [:NUMBER, 44, 1, 10],
+      [:TIMES, '*', 1, 15],
+      [:LPAREN, '(', 1, 17],
+      [:IDENTIFIER, 's', 1, 18],
+      [:MINUS, '-', 1, 20],
+      [:IDENTIFIER, 't', 1, 22],
+      [:RPAREN, ')', 1, 23]
     ])
   end
 end

--- a/spec/unit/lex_spec.rb
+++ b/spec/unit/lex_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Lex::Lexer, 'lex' do
       rule(:LPAREN, /\(/)
       rule(:RPAREN, /\)/)
       rule(:EQUALS, /=/)
-      rule(:IDENTIFIER, /\A[_\$a-zA-Z][_\$0-9a-zA-Z]*/)
+      rule(:IDENTIFIER, /[_\$a-zA-Z][_\$0-9a-zA-Z]*/)
 
       rule(:NUMBER, /[0-9]+/) do |lexer, token|
         token.value = token.value.to_i

--- a/spec/unit/lex_spec.rb
+++ b/spec/unit/lex_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Lex::Lexer, 'lex' do
     ])
 
     # Test that lexer is correctly parsing if created token value isn't equal to original text
-    my_lexer = MyLexer.new
+    my_lexer.rewind
     code_with_prefix = unindent(<<-EOS)
       x = 05 + 0044 * (s - t)
     EOS

--- a/spec/unit/position_spec.rb
+++ b/spec/unit/position_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Lex::Lexer, 'position' do
 
       rule(:PLUS,   /\+/)
       rule(:EQUALS, /=/)
-      rule(:IDENTIFIER, /\A[_\$a-zA-Z][_\$0-9a-zA-Z]*/)
+      rule(:IDENTIFIER, /[_\$a-zA-Z][_\$0-9a-zA-Z]*/)
 
       rule(:NUMBER, /[0-9]+/) do |lexer, token|
         token.value = token.value.to_i


### PR DESCRIPTION
I would mainly appreciate upstream merging of
```
f840e44 Fixed advancing by wrong number of characters if lexer rule is returning custom value with different to_s length than original matched token text.
```
because without this fix it is effectively impossible to use custom types in rule token.value.

Remaining commits are just collateral fixes when I was checking the code.