### PR TITLE
Adds missing token to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ class MyLexer < Lex::Lexer
   rule(:DIVIDE, /\//)
   rule(:LPAREN, /\(/)
   rule(:RPAREN, /\)/)
+  rule(:EQUALS, /\=/)
   rule(:ID,     /\A[_\$a-zA-Z][_\$0-9a-zA-Z]*/)
 
   # A regular expression rules with actions


### PR DESCRIPTION
I tried to run the example but it threw an error as I was iterating through. Adding this to the example fixed the error for me.